### PR TITLE
2019/kw19/windows_lineendings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
Since it is not possible to compile this package with windows lineendings and I could not fix this issue, I decided to enforce unix line endings on the repo. Very ugly solution but what can one man do? ¯\\_(ツ)_/¯ 