### PR TITLE
Add grid component

### DIFF
--- a/src/system/components/layout/Grid/Grid.vue
+++ b/src/system/components/layout/Grid/Grid.vue
@@ -1,0 +1,44 @@
+<template>
+  <component
+    :is="tag"
+    class="ds-grid"
+    :style="styles"
+  >
+    <slot />
+  </component>
+</template>
+
+<script>
+export default {
+  name: 'DsGrid',
+  props: {
+    gap: {
+      type: Number,
+      default: 16, // TODO: how to use tokens.small here?
+    },
+    minColumnWidth: {
+      type: Number,
+      default: 300,
+    },
+    rowHeight: {
+      type: Number,
+      default: 20,
+    },
+    tag: {
+      type: String,
+      default: 'div',
+    },
+  },
+  computed: {
+    styles() {
+      return ({
+        gridTemplateColumns: `repeat(auto-fill, minmax(${this.minColumnWidth}px, 1fr`,
+        gridGap: `${this.gap}px`,
+        gridAutoRows: `${this.rowHeight}px`,
+      })
+    }
+  }
+}
+</script>
+
+<style lang="scss" src="./style.scss" />

--- a/src/system/components/layout/Grid/Grid.vue
+++ b/src/system/components/layout/Grid/Grid.vue
@@ -9,6 +9,8 @@
 </template>
 
 <script>
+import { getSpace } from '@@/utils'
+
 /**
  * Used in combination with the grid item component to create masonry layouts.
  * @version 1.0.0
@@ -21,8 +23,8 @@ export default {
      * The vertical and horizontal gap between grid items
      */
     gap: {
-      type: Number,
-      default: 16, // TODO: how to use tokens.small here?
+      type: String,
+      default: 'small',
     },
     /**
      * The minimum width of each column
@@ -50,7 +52,7 @@ export default {
     styles() {
       return {
         gridTemplateColumns: `repeat(auto-fill, minmax(${this.minColumnWidth}px, 1fr`,
-        gridGap: `${this.gap}px`,
+        gridGap: `${getSpace(this.gap)}px`,
         gridAutoRows: `${this.rowHeight}px`,
       }
     }

--- a/src/system/components/layout/Grid/Grid.vue
+++ b/src/system/components/layout/Grid/Grid.vue
@@ -21,10 +21,14 @@ export default {
   props: {
     /**
      * The vertical and horizontal gap between grid items
+     * @options xxx-small|xx-small|x-small|small|base|large|x-large|xx-large|xxx-large
      */
     gap: {
       type: String,
       default: 'small',
+      validator: value => (
+        value.match(/(xxx-small|xx-small|x-small|small|base|large|x-large|xx-large|xxx-large)/)
+      )
     },
     /**
      * The minimum width of each column

--- a/src/system/components/layout/Grid/Grid.vue
+++ b/src/system/components/layout/Grid/Grid.vue
@@ -9,6 +9,11 @@
 </template>
 
 <script>
+/**
+ * Used in combination with the grid item component to create masonry layouts.
+ * @version 1.0.0
+ */
+
 export default {
   name: 'DsGrid',
   props: {
@@ -18,7 +23,7 @@ export default {
     },
     minColumnWidth: {
       type: Number,
-      default: 300,
+      default: 250,
     },
     rowHeight: {
       type: Number,

--- a/src/system/components/layout/Grid/Grid.vue
+++ b/src/system/components/layout/Grid/Grid.vue
@@ -17,18 +17,30 @@
 export default {
   name: 'DsGrid',
   props: {
+    /**
+     * The vertical and horizontal gap between grid items
+     */
     gap: {
       type: Number,
       default: 16, // TODO: how to use tokens.small here?
     },
+    /**
+     * The minimum width of each column
+     */
     minColumnWidth: {
       type: Number,
       default: 250,
     },
+    /**
+     * The height of each row (recommended to use the default)
+     */
     rowHeight: {
       type: Number,
       default: 20,
     },
+    /**
+     * The outermost html tag
+     */
     tag: {
       type: String,
       default: 'div',

--- a/src/system/components/layout/Grid/Grid.vue
+++ b/src/system/components/layout/Grid/Grid.vue
@@ -31,14 +31,17 @@ export default {
   },
   computed: {
     styles() {
-      return ({
+      return {
         gridTemplateColumns: `repeat(auto-fill, minmax(${this.minColumnWidth}px, 1fr`,
         gridGap: `${this.gap}px`,
         gridAutoRows: `${this.rowHeight}px`,
-      })
+      }
     }
-  }
+  },
 }
 </script>
 
-<style lang="scss" src="./style.scss" />
+<style lang="scss" src="./style.scss">
+</style>
+
+<docs src="./demo.md"></docs>

--- a/src/system/components/layout/Grid/GridItem.vue
+++ b/src/system/components/layout/Grid/GridItem.vue
@@ -8,30 +8,44 @@
 </template>
 
 <script>
-  export default {
-    name: 'DsGridItem',
-    props: {
-      columnSpan: {
-        type: [String, Number],
-        default: 1,
-      },
-      rowSpan: {
-        type: Number,
-        default: 4,
-      },
-      tag: {
-        type: String,
-        default: 'div',
-      },
+/**
+ * @version 1.0.0
+ * @see DsGrid
+ */
+export default {
+  name: 'DsGridItem',
+  props: {
+    /**
+     * The number of columns the item will span
+     * @options 'fullWidth'|number
+     */
+    columnSpan: {
+      type: [String, Number],
+      default: 1,
     },
-    computed: {
-      styles() {
-        return {
-          gridRowEnd: `span ${this.rowSpan}`,
-          gridColumnStart: this.columnSpan === 'fullWidth' ? 1 : 'auto',
-          gridColumnEnd: this.columnSpan === 'fullWidth' ? -1 : `span ${this.columnSpan}`,
-        }
+    /**
+     * The number of rows the item will span
+     */
+    rowSpan: {
+      type: Number,
+      default: 4,
+    },
+    /**
+     * The outermost html tag
+     */
+    tag: {
+      type: String,
+      default: 'div',
+    },
+  },
+  computed: {
+    styles() {
+      return {
+        gridRowEnd: `span ${this.rowSpan}`,
+        gridColumnStart: this.columnSpan === 'fullWidth' ? 1 : 'auto',
+        gridColumnEnd: this.columnSpan === 'fullWidth' ? -1 : `span ${this.columnSpan}`,
       }
-    },
-  }
+    }
+  },
+}
 </script>

--- a/src/system/components/layout/Grid/GridItem.vue
+++ b/src/system/components/layout/Grid/GridItem.vue
@@ -1,0 +1,13 @@
+<template>
+  <component :is="tag">
+    <slot />
+  </component>
+</template>
+
+<script>
+  export default {
+  name: 'DsGridItem',
+  }
+</script>
+
+<style/>

--- a/src/system/components/layout/Grid/GridItem.vue
+++ b/src/system/components/layout/Grid/GridItem.vue
@@ -17,7 +17,7 @@
       },
       rowSpan: {
         type: Number,
-        default: 10,
+        default: 4,
       },
       tag: {
         type: String,

--- a/src/system/components/layout/Grid/GridItem.vue
+++ b/src/system/components/layout/Grid/GridItem.vue
@@ -1,13 +1,37 @@
 <template>
-  <component :is="tag">
+  <component
+    :is="tag"
+    :style="styles"
+  >
     <slot />
   </component>
 </template>
 
 <script>
   export default {
-  name: 'DsGridItem',
+    name: 'DsGridItem',
+    props: {
+      columnSpan: {
+        type: [String, Number],
+        default: 1,
+      },
+      rowSpan: {
+        type: Number,
+        default: 10,
+      },
+      tag: {
+        type: String,
+        default: 'div',
+      },
+    },
+    computed: {
+      styles() {
+        return {
+          gridRowEnd: `span ${this.rowSpan}`,
+          gridColumnStart: this.columnSpan === 'fullWidth' ? 1 : 'auto',
+          gridColumnEnd: this.columnSpan === 'fullWidth' ? -1 : `span ${this.columnSpan}`,
+        }
+      }
+    },
   }
 </script>
-
-<style/>

--- a/src/system/components/layout/Grid/demo.md
+++ b/src/system/components/layout/Grid/demo.md
@@ -1,0 +1,74 @@
+## Column Widths
+
+All columns share the space in the grid evenly. You can set a minimum width beyond which columns will continue to grow until there is enough space to fit another column of minimum width. (Resize the window to see the effect.)
+```
+<ds-grid min-column-width="200">
+  <ds-grid-item><ds-placeholder>same</ds-placeholder></ds-grid-item>
+  <ds-grid-item><ds-placeholder>same</ds-placeholder></ds-grid-item>
+  <ds-grid-item><ds-placeholder>same</ds-placeholder></ds-grid-item>
+  <ds-grid-item><ds-placeholder>same</ds-placeholder></ds-grid-item>
+</ds-grid>
+```
+
+## Gaps
+
+You can set a gap which will be applied as a vertical and horizontal space between all grid items.
+```
+<ds-grid gap="30">
+  <ds-grid-item><ds-placeholder>same</ds-placeholder></ds-grid-item>
+  <ds-grid-item><ds-placeholder>same</ds-placeholder></ds-grid-item>
+  <ds-grid-item><ds-placeholder>same</ds-placeholder></ds-grid-item>
+  <ds-grid-item><ds-placeholder>same</ds-placeholder></ds-grid-item>
+</ds-grid>
+```
+
+## Grid Item Size
+
+Once the grid is defined a grid item can span several columns and/or rows. You can adjust this by setting the column span and/or row span of each item individually. The column span can also be set to `'fullWidth'`.
+```
+<ds-grid>
+  <ds-grid-item column-span="fullWidth"><ds-placeholder>full width</ds-placeholder></ds-grid-item>
+  <ds-grid-item row-span="6" column-span="2"><ds-placeholder>2 columns, 6 rows</ds-placeholder></ds-grid-item>
+  <ds-grid-item row-span="8"><ds-placeholder>8 rows</ds-placeholder></ds-grid-item>
+  <ds-grid-item><ds-placeholder>default</ds-placeholder></ds-grid-item>
+</ds-grid>
+```
+
+## Row Height
+
+You can set a row height – but this is only recommended in combination with the grid item property `row-span`! With these values you can fine tune the height of grid items which will always be a multiple of the defined row height.
+
+Low row heights leads to a more flexible item height:
+```
+<ds-grid row-height="4">
+  <ds-grid-item row-span="10"><ds-placeholder>same</ds-placeholder></ds-grid-item>
+  <ds-grid-item row-span="11"><ds-placeholder>same</ds-placeholder></ds-grid-item>
+  <ds-grid-item row-span="12"><ds-placeholder>same</ds-placeholder></ds-grid-item>
+</ds-grid>
+```
+
+High row height leads to a less flexible item height:
+```
+<ds-grid row-height="100">
+  <ds-grid-item row-span="1"><ds-placeholder>same</ds-placeholder></ds-grid-item>
+  <ds-grid-item row-span="2"><ds-placeholder>same</ds-placeholder></ds-grid-item>
+  <ds-grid-item row-span="3"><ds-placeholder>same</ds-placeholder></ds-grid-item>
+</ds-grid>
+```
+
+## Masonry Layout
+
+In a classic masonry layout items usually have the same width but different heights and are sorted from left to right then top to bottom. You can achieve this by setting the `min-column-width` and `gap` properties for the grid (or using the defaults) and then calculating the `row-span` for each grid item depending on its contents.
+
+Some items may move slightly out of order to make sure existing rows are filled before creating new ones.
+```
+<ds-grid>
+  <ds-grid-item row-span="4"><ds-placeholder>first</ds-placeholder></ds-grid-item>
+  <ds-grid-item row-span="8"><ds-placeholder>second</ds-placeholder></ds-grid-item>
+  <ds-grid-item row-span="6"><ds-placeholder>third</ds-placeholder></ds-grid-item>
+  <ds-grid-item row-span="6"><ds-placeholder>fourth</ds-placeholder></ds-grid-item>
+  <ds-grid-item row-span="4"><ds-placeholder>fifth</ds-placeholder></ds-grid-item>
+  <ds-grid-item row-span="8"><ds-placeholder>sixth</ds-placeholder></ds-grid-item>
+  <ds-grid-item row-span="4"><ds-placeholder>seventh</ds-placeholder></ds-grid-item>
+</ds-grid>
+```

--- a/src/system/components/layout/Grid/demo.md
+++ b/src/system/components/layout/Grid/demo.md
@@ -1,6 +1,8 @@
-## Column Widths
+## Column Width
 
-All columns share the space in the grid evenly. You can set a minimum width beyond which columns will continue to grow until there is enough space to fit another column of minimum width. (Resize the window to see the effect.)
+All columns share the space in the grid evenly and grow and shrink dynamically.
+
+You can set a minimum width beyond which columns will continue to grow until there is enough space to fit another column of minimum width. (Resize the window to see the effect.)
 ```
 <ds-grid min-column-width="200">
   <ds-grid-item><ds-placeholder>same</ds-placeholder></ds-grid-item>
@@ -12,9 +14,9 @@ All columns share the space in the grid evenly. You can set a minimum width beyo
 
 ## Gaps
 
-You can set a gap which will be applied as a vertical and horizontal space between all grid items.
+You can set a gap which will be applied as a vertical and horizontal space between all grid items. Allowed values are [the common space sizes](/design-tokens/#spaceSize) and `0`. The default is `small`.
 ```
-<ds-grid gap="30">
+<ds-grid gap="x-small">
   <ds-grid-item><ds-placeholder>same</ds-placeholder></ds-grid-item>
   <ds-grid-item><ds-placeholder>same</ds-placeholder></ds-grid-item>
   <ds-grid-item><ds-placeholder>same</ds-placeholder></ds-grid-item>
@@ -30,15 +32,15 @@ Once the grid is defined a grid item can span several columns and/or rows. You c
   <ds-grid-item column-span="fullWidth"><ds-placeholder>full width</ds-placeholder></ds-grid-item>
   <ds-grid-item row-span="6" column-span="2"><ds-placeholder>2 columns, 6 rows</ds-placeholder></ds-grid-item>
   <ds-grid-item row-span="8"><ds-placeholder>8 rows</ds-placeholder></ds-grid-item>
-  <ds-grid-item><ds-placeholder>default</ds-placeholder></ds-grid-item>
+  <ds-grid-item><ds-placeholder>default (1 column, 4 rows)</ds-placeholder></ds-grid-item>
 </ds-grid>
 ```
 
 ## Row Height
 
-You can set a row height – but this is only recommended in combination with the grid item property `row-span`! With these values you can fine tune the height of grid items which will always be a multiple of the defined row height.
+You can set the height of a row – but this is only recommended in combination with setting the grid item property `row-span`! With these values you can fine tune the height of grid items which will always be a multiple of the defined `row-height`.
 
-Low row heights leads to a more flexible item height:
+Low row height leads to a more fine-grained item height:
 ```
 <ds-grid row-height="4">
   <ds-grid-item row-span="10"><ds-placeholder>same</ds-placeholder></ds-grid-item>
@@ -47,7 +49,7 @@ Low row heights leads to a more flexible item height:
 </ds-grid>
 ```
 
-High row height leads to a less flexible item height:
+High row height leads to a rougher item height:
 ```
 <ds-grid row-height="100">
   <ds-grid-item row-span="1"><ds-placeholder>same</ds-placeholder></ds-grid-item>
@@ -58,7 +60,7 @@ High row height leads to a less flexible item height:
 
 ## Masonry Layout
 
-In a classic masonry layout items usually have the same width but different heights and are sorted from left to right then top to bottom. You can achieve this by setting the `min-column-width` and `gap` properties for the grid (or using the defaults) and then calculating the `row-span` for each grid item depending on its contents.
+In a classic masonry layout items usually have the same width but different heights and are sorted from left to right then top to bottom. You can achieve this by calculating and setting the `row-span` programmatically for each grid item, depending on its contents.
 
 Some items may move slightly out of order to make sure existing rows are filled before creating new ones.
 ```

--- a/src/system/components/layout/Grid/demo.md
+++ b/src/system/components/layout/Grid/demo.md
@@ -4,7 +4,7 @@ All columns share the space in the grid evenly and grow and shrink dynamically.
 
 You can set a minimum width beyond which columns will continue to grow until there is enough space to fit another column of minimum width. (Resize the window to see the effect.)
 ```
-<ds-grid min-column-width="200">
+<ds-grid :min-column-width="200">
   <ds-grid-item><ds-placeholder>same</ds-placeholder></ds-grid-item>
   <ds-grid-item><ds-placeholder>same</ds-placeholder></ds-grid-item>
   <ds-grid-item><ds-placeholder>same</ds-placeholder></ds-grid-item>
@@ -30,8 +30,8 @@ Once the grid is defined a grid item can span several columns and/or rows. You c
 ```
 <ds-grid>
   <ds-grid-item column-span="fullWidth"><ds-placeholder>full width</ds-placeholder></ds-grid-item>
-  <ds-grid-item row-span="6" column-span="2"><ds-placeholder>2 columns, 6 rows</ds-placeholder></ds-grid-item>
-  <ds-grid-item row-span="8"><ds-placeholder>8 rows</ds-placeholder></ds-grid-item>
+  <ds-grid-item :row-span="6" :column-span="2"><ds-placeholder>2 columns, 6 rows</ds-placeholder></ds-grid-item>
+  <ds-grid-item :row-span="8"><ds-placeholder>8 rows</ds-placeholder></ds-grid-item>
   <ds-grid-item><ds-placeholder>default (1 column, 4 rows)</ds-placeholder></ds-grid-item>
 </ds-grid>
 ```
@@ -42,19 +42,19 @@ You can set the height of a row – but this is only recommended in combination 
 
 Low row height leads to a more fine-grained item height:
 ```
-<ds-grid row-height="4">
-  <ds-grid-item row-span="10"><ds-placeholder>same</ds-placeholder></ds-grid-item>
-  <ds-grid-item row-span="11"><ds-placeholder>same</ds-placeholder></ds-grid-item>
-  <ds-grid-item row-span="12"><ds-placeholder>same</ds-placeholder></ds-grid-item>
+<ds-grid :row-height="4">
+  <ds-grid-item :row-span="10"><ds-placeholder>same</ds-placeholder></ds-grid-item>
+  <ds-grid-item :row-span="11"><ds-placeholder>same</ds-placeholder></ds-grid-item>
+  <ds-grid-item :row-span="12"><ds-placeholder>same</ds-placeholder></ds-grid-item>
 </ds-grid>
 ```
 
 High row height leads to a rougher item height:
 ```
-<ds-grid row-height="100">
-  <ds-grid-item row-span="1"><ds-placeholder>same</ds-placeholder></ds-grid-item>
-  <ds-grid-item row-span="2"><ds-placeholder>same</ds-placeholder></ds-grid-item>
-  <ds-grid-item row-span="3"><ds-placeholder>same</ds-placeholder></ds-grid-item>
+<ds-grid :row-height="100">
+  <ds-grid-item :row-span="1"><ds-placeholder>same</ds-placeholder></ds-grid-item>
+  <ds-grid-item :row-span="2"><ds-placeholder>same</ds-placeholder></ds-grid-item>
+  <ds-grid-item :row-span="3"><ds-placeholder>same</ds-placeholder></ds-grid-item>
 </ds-grid>
 ```
 
@@ -65,12 +65,14 @@ In a classic masonry layout items usually have the same width but different heig
 Some items may move slightly out of order to make sure existing rows are filled before creating new ones.
 ```
 <ds-grid>
-  <ds-grid-item row-span="4"><ds-placeholder>first</ds-placeholder></ds-grid-item>
-  <ds-grid-item row-span="8"><ds-placeholder>second</ds-placeholder></ds-grid-item>
-  <ds-grid-item row-span="6"><ds-placeholder>third</ds-placeholder></ds-grid-item>
-  <ds-grid-item row-span="6"><ds-placeholder>fourth</ds-placeholder></ds-grid-item>
-  <ds-grid-item row-span="4"><ds-placeholder>fifth</ds-placeholder></ds-grid-item>
-  <ds-grid-item row-span="8"><ds-placeholder>sixth</ds-placeholder></ds-grid-item>
-  <ds-grid-item row-span="4"><ds-placeholder>seventh</ds-placeholder></ds-grid-item>
+  <ds-grid-item :row-span="4"><ds-placeholder>first</ds-placeholder></ds-grid-item>
+  <ds-grid-item :row-span="8"><ds-placeholder>second</ds-placeholder></ds-grid-item>
+  <ds-grid-item :row-span="6"><ds-placeholder>third</ds-placeholder></ds-grid-item>
+  <ds-grid-item :row-span="6"><ds-placeholder>fourth</ds-placeholder></ds-grid-item>
+  <ds-grid-item :row-span="4"><ds-placeholder>fifth</ds-placeholder></ds-grid-item>
+  <ds-grid-item :row-span="8"><ds-placeholder>sixth</ds-placeholder></ds-grid-item>
+  <ds-grid-item :row-span="4"><ds-placeholder>seventh</ds-placeholder></ds-grid-item>
 </ds-grid>
 ```
+
+**Hint:** Make sure to pass `numbers` with a colon (shortcut for `v-bind:`) so they are not interpreted as strings. For a more thorough explanation visit [the Vue.js docs](https://vuejs.org/v2/guide/components-props.html#Passing-a-Number).

--- a/src/system/components/layout/Grid/style.scss
+++ b/src/system/components/layout/Grid/style.scss
@@ -1,0 +1,3 @@
+.ds-grid {
+  display: grid;
+}

--- a/src/system/components/layout/Placeholder/style.scss
+++ b/src/system/components/layout/Placeholder/style.scss
@@ -1,5 +1,6 @@
 .ds-placeholder {
   @include reset;
+  height: 100%;
   padding: $space-base;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## 🍰 Pullrequest
Adds a `Grid` and `Grid-Item` component to the styleguide to allow for the creation of masonry layouts.

### Issues
- relates to https://github.com/Human-Connection/Human-Connection/issues/378

### ToDo
- [x] Validate that `gap` is one of the common [space size](https://styleguide.human-connection.org/design-tokens/#spaceSize) tokens or `0`. (At the moment invalid input is set to `0`, which might be ok, too?)