### PR TITLE
Fix grid component

### DIFF
--- a/src/system/components/layout/Grid/Grid.vue
+++ b/src/system/components/layout/Grid/Grid.vue
@@ -55,7 +55,7 @@ export default {
   computed: {
     styles() {
       return {
-        gridTemplateColumns: `repeat(auto-fill, minmax(${this.minColumnWidth}px, 1fr`,
+        gridTemplateColumns: `repeat(auto-fill, minmax(${this.minColumnWidth}px, 1fr))`,
         gridGap: `${getSpace(this.gap)}px`,
         gridAutoRows: `${this.rowHeight}px`,
       }


### PR DESCRIPTION
Add missing `))`

This will repair the default grid-layout – and fix https://github.com/Human-Connection/Human-Connection/issues/1425 as soon as we update the styleguide in the project.