### PR TITLE
Use babel-loader to transpile svgs

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -32,7 +32,7 @@ module.exports = {
           loader: process.env.BUILD === 'library'
             ? require.resolve('./src/loader/docs-trim-loader.js')
             : require.resolve('./src/loader/docs-loader.js')
-        }
+        },
       ]
     },
     plugins: process.env.BUILD === 'library'
@@ -64,6 +64,9 @@ module.exports = {
     const svgRule = config.module.rule('svg')
     svgRule.uses.clear()
     svgRule
+      .use('babel-loader')
+      .loader('babel-loader')
+      .end()
       .use('vue-svg-loader')
       .loader('vue-svg-loader')
       .options({


### PR DESCRIPTION
IE and Edge are having trouble loading the Human Connection network because object spread operators are left in the minified code – using `babel-loader` for `svgs` (as suggested in the [vue-svg-loader docs](https://vue-svg-loader.js.org/#configuration)) hopefully solves this issue.

--> relates to https://github.com/Human-Connection/Human-Connection/issues/2287
